### PR TITLE
Replace multiple dashes with one

### DIFF
--- a/index.js
+++ b/index.js
@@ -15,6 +15,7 @@ function slug(content, separator) {
     var s = content
         .replace(re, '')
         .replace(/ /g, separator)
+        .replace(/-{2,}/g, '-')
         .toLowerCase();
 
     if (s[0] == separator) s = s.slice(1);

--- a/test/test.js
+++ b/test/test.js
@@ -4,10 +4,10 @@ var should = require('should');
 var MATCHES = {
     'hello': 'hello',
     'hello world': 'hello-world',
-    '!weird + id/for headings': 'weird--idfor-heading',
+    '!weird + id/for headings': 'weird-idfor-heading',
     '您好': '您好',
-    'I ♥ you': 'i--you',
-    'a > b': 'a--b',
+    'I ♥ you': 'i-you',
+    'a > b': 'a-b',
     'Schöner Titel läßt grüßen!? Bel été !': 'schöner-titel-läßt-grüßen-bel-été-'
 }
 


### PR DESCRIPTION
Replace multiple dashes with just one, eg. when having special character in the text.

So this `Data types & validations` becomes `data-types-validations` and not `data-types--validations` how it behaves now.

If this should mimic GitHub, that's how GitHub works.